### PR TITLE
add activity feed api

### DIFF
--- a/apps/frontend/.react-router/types/+register.ts
+++ b/apps/frontend/.react-router/types/+register.ts
@@ -1,0 +1,17 @@
+import "react-router";
+
+declare module "react-router" {
+  interface Register {
+    params: Params;
+  }
+
+  interface Future {
+    unstable_middleware: false
+  }
+}
+
+type Params = {
+  "/": {};
+  "/auth/register": {};
+  "/auth/login": {};
+};

--- a/apps/frontend/.react-router/types/+virtual.d.ts
+++ b/apps/frontend/.react-router/types/+virtual.d.ts
@@ -1,0 +1,15 @@
+declare module "virtual:react-router/server-build" {
+  import { ServerBuild } from "react-router";
+  export const assets: ServerBuild["assets"];
+  export const assetsBuildDirectory: ServerBuild["assetsBuildDirectory"];
+  export const basename: ServerBuild["basename"];
+  export const entry: ServerBuild["entry"];
+  export const future: ServerBuild["future"];
+  export const isSpaMode: ServerBuild["isSpaMode"];
+  export const prerender: ServerBuild["prerender"];
+  export const publicPath: ServerBuild["publicPath"];
+  export const routeDiscovery: ServerBuild["routeDiscovery"];
+  export const routes: ServerBuild["routes"];
+  export const ssr: ServerBuild["ssr"];
+  export const unstable_getCriticalCss: ServerBuild["unstable_getCriticalCss"];
+}

--- a/apps/frontend/.react-router/types/app/+types/root.ts
+++ b/apps/frontend/.react-router/types/app/+types/root.ts
@@ -1,0 +1,42 @@
+// React Router generated types for route:
+// root.tsx
+
+import type * as T from "react-router/route-module"
+
+
+
+type Module = typeof import("../root.js")
+
+export type Info = {
+  parents: [],
+  id: "root"
+  file: "root.tsx"
+  path: ""
+  params: {} & { [key: string]: string | undefined }
+  module: Module
+  loaderData: T.CreateLoaderData<Module>
+  actionData: T.CreateActionData<Module>
+}
+
+export namespace Route {
+  export type LinkDescriptors = T.LinkDescriptors
+  export type LinksFunction = () => LinkDescriptors
+
+  export type MetaArgs = T.CreateMetaArgs<Info>
+  export type MetaDescriptors = T.MetaDescriptors
+  export type MetaFunction = (args: MetaArgs) => MetaDescriptors
+
+  export type HeadersArgs = T.HeadersArgs
+  export type HeadersFunction = (args: HeadersArgs) => Headers | HeadersInit
+
+  export type unstable_MiddlewareFunction = T.CreateServerMiddlewareFunction<Info>
+  export type unstable_ClientMiddlewareFunction = T.CreateClientMiddlewareFunction<Info>
+  export type LoaderArgs = T.CreateServerLoaderArgs<Info>
+  export type ClientLoaderArgs = T.CreateClientLoaderArgs<Info>
+  export type ActionArgs = T.CreateServerActionArgs<Info>
+  export type ClientActionArgs = T.CreateClientActionArgs<Info>
+
+  export type HydrateFallbackProps = T.CreateHydrateFallbackProps<Info>
+  export type ComponentProps = T.CreateComponentProps<Info>
+  export type ErrorBoundaryProps = T.CreateErrorBoundaryProps<Info>
+}

--- a/apps/frontend/.react-router/types/app/routes/+types/_index.ts
+++ b/apps/frontend/.react-router/types/app/routes/+types/_index.ts
@@ -1,0 +1,42 @@
+// React Router generated types for route:
+// routes/_index.tsx
+
+import type * as T from "react-router/route-module"
+
+import type { Info as Parent0 } from "../../+types/root.js"
+
+type Module = typeof import("../_index.js")
+
+export type Info = {
+  parents: [Parent0],
+  id: "routes/_index"
+  file: "routes/_index.tsx"
+  path: "undefined"
+  params: {} & { [key: string]: string | undefined }
+  module: Module
+  loaderData: T.CreateLoaderData<Module>
+  actionData: T.CreateActionData<Module>
+}
+
+export namespace Route {
+  export type LinkDescriptors = T.LinkDescriptors
+  export type LinksFunction = () => LinkDescriptors
+
+  export type MetaArgs = T.CreateMetaArgs<Info>
+  export type MetaDescriptors = T.MetaDescriptors
+  export type MetaFunction = (args: MetaArgs) => MetaDescriptors
+
+  export type HeadersArgs = T.HeadersArgs
+  export type HeadersFunction = (args: HeadersArgs) => Headers | HeadersInit
+
+  export type unstable_MiddlewareFunction = T.CreateServerMiddlewareFunction<Info>
+  export type unstable_ClientMiddlewareFunction = T.CreateClientMiddlewareFunction<Info>
+  export type LoaderArgs = T.CreateServerLoaderArgs<Info>
+  export type ClientLoaderArgs = T.CreateClientLoaderArgs<Info>
+  export type ActionArgs = T.CreateServerActionArgs<Info>
+  export type ClientActionArgs = T.CreateClientActionArgs<Info>
+
+  export type HydrateFallbackProps = T.CreateHydrateFallbackProps<Info>
+  export type ComponentProps = T.CreateComponentProps<Info>
+  export type ErrorBoundaryProps = T.CreateErrorBoundaryProps<Info>
+}

--- a/apps/frontend/.react-router/types/app/routes/auth.login/+types/route.ts
+++ b/apps/frontend/.react-router/types/app/routes/auth.login/+types/route.ts
@@ -1,0 +1,42 @@
+// React Router generated types for route:
+// routes/auth.login/route.tsx
+
+import type * as T from "react-router/route-module"
+
+import type { Info as Parent0 } from "../../../+types/root.js"
+
+type Module = typeof import("../route.js")
+
+export type Info = {
+  parents: [Parent0],
+  id: "routes/auth.login"
+  file: "routes/auth.login/route.tsx"
+  path: "auth/login"
+  params: {} & { [key: string]: string | undefined }
+  module: Module
+  loaderData: T.CreateLoaderData<Module>
+  actionData: T.CreateActionData<Module>
+}
+
+export namespace Route {
+  export type LinkDescriptors = T.LinkDescriptors
+  export type LinksFunction = () => LinkDescriptors
+
+  export type MetaArgs = T.CreateMetaArgs<Info>
+  export type MetaDescriptors = T.MetaDescriptors
+  export type MetaFunction = (args: MetaArgs) => MetaDescriptors
+
+  export type HeadersArgs = T.HeadersArgs
+  export type HeadersFunction = (args: HeadersArgs) => Headers | HeadersInit
+
+  export type unstable_MiddlewareFunction = T.CreateServerMiddlewareFunction<Info>
+  export type unstable_ClientMiddlewareFunction = T.CreateClientMiddlewareFunction<Info>
+  export type LoaderArgs = T.CreateServerLoaderArgs<Info>
+  export type ClientLoaderArgs = T.CreateClientLoaderArgs<Info>
+  export type ActionArgs = T.CreateServerActionArgs<Info>
+  export type ClientActionArgs = T.CreateClientActionArgs<Info>
+
+  export type HydrateFallbackProps = T.CreateHydrateFallbackProps<Info>
+  export type ComponentProps = T.CreateComponentProps<Info>
+  export type ErrorBoundaryProps = T.CreateErrorBoundaryProps<Info>
+}

--- a/apps/frontend/.react-router/types/app/routes/auth.register/+types/route.ts
+++ b/apps/frontend/.react-router/types/app/routes/auth.register/+types/route.ts
@@ -1,0 +1,42 @@
+// React Router generated types for route:
+// routes/auth.register/route.tsx
+
+import type * as T from "react-router/route-module"
+
+import type { Info as Parent0 } from "../../../+types/root.js"
+
+type Module = typeof import("../route.js")
+
+export type Info = {
+  parents: [Parent0],
+  id: "routes/auth.register"
+  file: "routes/auth.register/route.tsx"
+  path: "auth/register"
+  params: {} & { [key: string]: string | undefined }
+  module: Module
+  loaderData: T.CreateLoaderData<Module>
+  actionData: T.CreateActionData<Module>
+}
+
+export namespace Route {
+  export type LinkDescriptors = T.LinkDescriptors
+  export type LinksFunction = () => LinkDescriptors
+
+  export type MetaArgs = T.CreateMetaArgs<Info>
+  export type MetaDescriptors = T.MetaDescriptors
+  export type MetaFunction = (args: MetaArgs) => MetaDescriptors
+
+  export type HeadersArgs = T.HeadersArgs
+  export type HeadersFunction = (args: HeadersArgs) => Headers | HeadersInit
+
+  export type unstable_MiddlewareFunction = T.CreateServerMiddlewareFunction<Info>
+  export type unstable_ClientMiddlewareFunction = T.CreateClientMiddlewareFunction<Info>
+  export type LoaderArgs = T.CreateServerLoaderArgs<Info>
+  export type ClientLoaderArgs = T.CreateClientLoaderArgs<Info>
+  export type ActionArgs = T.CreateServerActionArgs<Info>
+  export type ClientActionArgs = T.CreateClientActionArgs<Info>
+
+  export type HydrateFallbackProps = T.CreateHydrateFallbackProps<Info>
+  export type ComponentProps = T.CreateComponentProps<Info>
+  export type ErrorBoundaryProps = T.CreateErrorBoundaryProps<Info>
+}

--- a/apps/frontend/graphite-demo/server.js
+++ b/apps/frontend/graphite-demo/server.js
@@ -1,0 +1,30 @@
+const express = require('express');
+const app = express();
+const port = 3000;
+
+// Fake data for the activity feed
+const activityFeed = [
+  {
+    id: 1000,
+    title: 'New Photo Uploaded',
+    body: 'Alice uploaded a new photo to her album.'
+  },
+  {
+    id: 2000,
+    title: 'Comment on Post',
+    body: "Bob commented on Charlie's post."
+  },
+  {
+    id: 13,
+    title: 'Status Update',
+    body: 'Charlie updated their status: "Excited about the new project!"'
+  }
+];
+
+app.get('/feed', (req, res) => {
+  res.json(activityFeed);
+});
+
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});


### PR DESCRIPTION
# Add Demo Server

### TL;DR

Created a simple Express server for demo purposes.

### What changed?

- Created a simple Express server in `graphite-demo/server.js` that:
  - Serves a mock activity feed endpoint at `/feed`
  - Returns sample activity data with titles and body content

### How to test?

1. Start the Express server:
   ```
   cd apps/frontend/graphite-demo
   node server.js
   ```
2. Access the activity feed endpoint at `http://localhost:3000/feed`
3. Verify the server returns the mock activity feed data

### Why make this change?

The Express server provides a simple backend for demo purposes, allowing frontend components to fetch and display activity feed data during development.